### PR TITLE
splitting data with the help of blosum 62 scoring matrix.

### DIFF
--- a/Bioinformatics/AffineGapPenaltySequenceAlignment.md
+++ b/Bioinformatics/AffineGapPenaltySequenceAlignment.md
@@ -18,7 +18,7 @@ GACTACAGCTCGTATACGCACACATGGTTCAGAC
 |G|-5|2|-7|-7|
 |T|-7|-7|2|-5|
 |C|-7|-7|-5|2|
-
+# ------------
 JavaScript source code:
 ```JavaScript
 var seq2 = "GACTACGATCCGTATACGCACAGGTTCAGAC";


### PR DESCRIPTION
hi,
would it be possible to split the sequences into test and train set in such a way that the sequences in both test and train should not share more than 30% sequence identity.
i am searching this for minimizing overlapping sequences data from test and train set.
thank you.